### PR TITLE
run bundle lock --add-platform ruby / bundle lock --add-platform x86_64-linux / bundle install

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,6 +173,8 @@ GEM
     nokogiri (1.13.8)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
+    nokogiri (1.13.8-x86_64-linux)
+      racc (~> 1.4)
     orm_adapter (0.5.0)
     os (1.1.4)
     pg (1.4.3)
@@ -339,6 +341,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   autoprefixer-rails


### PR DESCRIPTION
cf doc https://devcenter.heroku.com/articles/bundler-version#known-upgrade-issues